### PR TITLE
Chore: add missing dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.14",
         "@types/node": "^22.8.1",
+        "@vercel/ncc": "^0.38.3",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "typescript": "^5.6.3"
@@ -1167,6 +1168,16 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true
+    },
+    "node_modules/@vercel/ncc": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.3.tgz",
+      "integrity": "sha512-rnK6hJBS6mwc+Bkab+PGPs9OiS0i/3kdTO+CkI8V0/VrW3vmz7O2Pxjw/owOlmo6PKEIxRSeZKv/kuL9itnpYA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
+      }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "@types/node": "^22.8.1",
+    "@vercel/ncc": "^0.38.3",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "typescript": "^5.6.3"


### PR DESCRIPTION
Added `@vercel/ncc` as `devDependency` instead of assuming the user has it installed globally